### PR TITLE
Fixed README hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Topics have the same sorting algorithms of reddit, as it goes more popular with 
 
 
 Take a look at the [API](https://github.com/Mohammed-Farid/gossipy-server).
-Come to visit at [Gossipy](gossipy.mohammedfarid.me)
+Come to visit at [Gossipy](http://gossipy.mohammedfarid.me/)


### PR DESCRIPTION
Old hyperlink redirected to [this url](https://github.com/Mohammed-Farid/gossipy/blob/master/gossipy.mohammedfarid.me) but now it redirects to the correct web app.